### PR TITLE
Add an API Client package

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,3 +1,17 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package client
 
 import (

--- a/client/client.go
+++ b/client/client.go
@@ -24,6 +24,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
 	"github.com/amalgam8/registry/api/protocol/amalgam8"
 )
 
@@ -40,8 +41,8 @@ type Client interface {
 }
 
 type ClientConfig struct {
-	URL       string
-	AuthToken string
+	URL        string
+	AuthToken  string
 	HTTPClient *http.Client
 }
 
@@ -59,7 +60,7 @@ func NewRESTClient(config ClientConfig) (*RESTClient, error) {
 	}
 
 	client := &RESTClient{
-		config:     config,
+		config: config,
 	}
 
 	if config.HTTPClient != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -26,6 +26,8 @@ import (
 	"time"
 )
 
+const defaultTimeout = time.Second * 30
+
 // Client defines the interface used by clients of the Amalgam8 Service Registry.
 type Client interface {
 	Register(instance *ServiceInstance) (*ServiceInstance, error)
@@ -36,12 +38,12 @@ type Client interface {
 	ListServiceInstances(serviceName string) ([]*ServiceInstance, error)
 }
 
-// TODO: Allow custom transport/HTTP client/TLS config
 // TODO: revamp URLs construction (resolve, URL-encode)
 
 type ClientConfig struct {
-	URL       string `json:"url"`
-	AuthToken string `json:"auth_token"`
+	URL       string
+	AuthToken string
+	HTTPClient *http.Client
 }
 
 // RESTClient implements the Client interface using Amalgam8 Service Registry REST API.
@@ -59,8 +61,16 @@ func NewRESTClient(config ClientConfig) (*RESTClient, error) {
 
 	client := &RESTClient{
 		config:     config,
-		httpClient: &http.Client{},
 	}
+
+	if config.HTTPClient != nil {
+		client.httpClient = config.HTTPClient
+	} else {
+		client.httpClient = &http.Client{
+			Timeout: defaultTimeout,
+		}
+	}
+	
 	return client, nil
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -169,7 +169,11 @@ func (client *RESTClient) doRequest(method string, path string, body interface{}
 		return nil, newError(ErrorCodeInternalClientError, "error creating HTTP request", err, "")
 	}
 
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.config.AuthToken))
+	// Add authorization header
+	if client.config.AuthToken != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.config.AuthToken))
+	}
+
 	if body != nil {
 		// Body exists, and encoded as JSON
 		req.Header.Set("Content-Type", "application/json")
@@ -223,7 +227,6 @@ func (client *RESTClient) doRequest(method string, path string, body interface{}
 		return nil, newError(ErrorCodeInternalClientError, message, nil, requestID)
 	}
 }
-
 
 func normalizeConfig(config *ClientConfig) error {
 	if config == nil {

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,231 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Client defines the interface used by clients of the Amalgam8 Service Registry.
+type Client interface {
+	Register(instance *ServiceInstance) (*ServiceInstance, error)
+	Deregister(id string) error
+	Renew(id string) error
+	ListServices() ([]string, error)
+	ListInstances(instanceFilter *InstanceFilter) ([]*ServiceInstance, error)
+	ListServiceInstances(serviceName string) ([]*ServiceInstance, error)
+}
+
+// TODO: Allow custom transport/HTTP client/TLS config
+// TODO: revamp URLs construction (resolve, URL-encode)
+
+type ClientConfig struct {
+	URL       string `json:"url"`
+	AuthToken string `json:"auth_token"`
+}
+
+// RESTClient implements the Client interface using Amalgam8 Service Registry REST API.
+type RESTClient struct {
+	config     ClientConfig
+	httpClient *http.Client
+}
+
+func NewRESTClient(config ClientConfig) (*RESTClient, error) {
+	// Validate and normalize configuration
+	err := normalizeConfig(&config)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &RESTClient{
+		config:     config,
+		httpClient: &http.Client{},
+	}
+	return client, nil
+}
+
+func (client *RESTClient) Register(instance *ServiceInstance) (*ServiceInstance, error) {
+	// Record a pessimistic last heartbeat time - Better safe than sorry!
+	lastHeartbeat := time.Now()
+
+	url := fmt.Sprintf("%s/api/v1/instances", client.config.URL)
+	body, err := client.doRequest("POST", url, instance, http.StatusCreated)
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[string]interface{})
+	err = json.Unmarshal(body, &m)
+	if err != nil {
+		return nil, newError(ErrorCodeInternalClientError, "error unmarshaling HTTP response body", err, "")
+	}
+
+	// TODO: recover type conversion panic
+	registeredInstance := &*instance
+	registeredInstance.ID = m["id"].(string)
+	registeredInstance.TTL = int(m["ttl"].(float64))
+	registeredInstance.LastHeartbeat = lastHeartbeat
+	return registeredInstance, nil
+}
+
+func (client *RESTClient) Deregister(id string) error {
+	uri := fmt.Sprintf("%s/api/v1/instances/%s", client.config.URL, id)
+	_, err := client.doRequest("DELETE", uri, nil, http.StatusOK)
+	return err
+}
+
+func (client *RESTClient) Renew(id string) error {
+	uri := fmt.Sprintf("%s/api/v1/instances/%s/heartbeat", client.config.URL, id)
+	_, err := client.doRequest("PUT", uri, nil, http.StatusOK)
+	return err
+}
+
+func (client *RESTClient) ListServices() ([]string, error) {
+	uri := fmt.Sprintf("%s/api/v1/services", client.config.URL)
+	body, err := client.doRequest("GET", uri, nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	s := struct {
+		Services []string `json:"services"`
+	}{}
+	err = json.Unmarshal(body, &s)
+	if err != nil {
+		return nil, newError(ErrorCodeInternalClientError, "error unmarshaling HTTP response body", err, "")
+	}
+	return s.Services, nil
+}
+
+func (client *RESTClient) ListServiceInstances(serviceName string) ([]*ServiceInstance, error) {
+	return client.ListInstances(&InstanceFilter{
+		ServiceName: serviceName,
+	})
+}
+
+func (client *RESTClient) ListInstances(instanceFilter *InstanceFilter) ([]*ServiceInstance, error) {
+	uri := fmt.Sprintf("%s/api/v1/instances", client.config.URL)
+
+	if instanceFilter != nil {
+		queryParams := instanceFilter.asQueryParams()
+		if len(queryParams) > 0 {
+			uri = fmt.Sprintf("%s?%s", uri, queryParams.Encode())
+		}
+		instanceFilter.asQueryParams()
+	}
+
+	body, err := client.doRequest("GET", uri, nil, http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+
+	s := struct {
+		Instances []*ServiceInstance `json:"instances"`
+	}{}
+	err = json.Unmarshal(body, &s)
+	if err != nil {
+		return nil, newError(ErrorCodeInternalClientError, "error unmarshaling HTTP response body", err, "")
+	}
+	return s.Instances, nil
+}
+
+func (client *RESTClient) doRequest(method string, uri string, body interface{}, status int) ([]byte, error) {
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return nil, newError(ErrorCodeInternalClientError, "error marshaling HTTP request body", err, "")
+		}
+		reader = bytes.NewBuffer(b)
+	}
+
+	req, err := http.NewRequest(method, uri, reader)
+	if err != nil {
+		return nil, newError(ErrorCodeInternalClientError, "error creating HTTP request", err, "")
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", client.config.AuthToken))
+	if body != nil {
+		// Body exists, and encoded as JSON
+		req.Header.Set("Content-Type", "application/json")
+	} else if method != "GET" {
+		// No body, but the server needs to know that too
+		req.Header.Set("Content-Length", "0")
+	}
+
+	resp, err := client.httpClient.Do(req)
+	if err != nil {
+		return nil, newError(ErrorCodeConnectionFailure, "error performing HTTP request", err, "")
+	}
+
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, newError(ErrorCodeConnectionFailure, "error read HTTP response body", err, "")
+	}
+
+	if resp.StatusCode == status {
+		return b, nil
+	}
+
+	requestID := resp.Header.Get("Sd-Request-Id")
+	message := string(b)
+	if requestID != "" {
+		s := struct {
+			Error string `json:"Error"`
+		}{}
+		err = json.Unmarshal(b, &s)
+		if err != nil {
+			message = s.Error
+		}
+	}
+	switch resp.StatusCode {
+	case http.StatusGone:
+		return nil, newError(ErrorCodeUnknownInstance, message, nil, requestID)
+	case http.StatusNotFound:
+		if requestID != "" {
+			return nil, newError(ErrorCodeInternalClientError, message, nil, requestID)
+		} else {
+			return nil, newError(ErrorCodeServiceUnavailable, message, nil, requestID)
+		}
+	case http.StatusBadGateway:
+		return nil, newError(ErrorCodeServiceUnavailable, message, nil, requestID)
+	case http.StatusUnauthorized:
+		return nil, newError(ErrorCodeUnauthorized, message, nil, requestID)
+	case http.StatusInternalServerError:
+		return nil, newError(ErrorCodeInternalServerError, message, nil, requestID)
+	default:
+		return nil, newError(ErrorCodeInternalClientError, message, nil, requestID)
+	}
+}
+
+func normalizeConfig(config *ClientConfig) error {
+	if config == nil {
+		return newError(ErrorCodeInvalidConfiguration, "client configuration cannot be nil", nil, "")
+	}
+
+	// Normalize server URL to not end with a "/"
+	config.URL = strings.TrimRight(config.URL, "/")
+
+	url, err := url.Parse(config.URL)
+	if err != nil {
+		return newError(ErrorCodeInvalidConfiguration, "cannot parse server URL", err, "")
+	}
+
+	if url.Scheme != "http" && url.Scheme != "https" {
+		return newError(ErrorCodeInvalidConfiguration, fmt.Sprintf("unsupported scheme %s", url.Scheme), nil, "")
+	}
+
+	url.Query()
+	if config.AuthToken == "" {
+		return newError(ErrorCodeInvalidConfiguration, "missing authentication token", nil, "")
+	}
+
+	return nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ type Client interface {
 	Deregister(id string) error
 	Renew(id string) error
 	ListServices() ([]string, error)
-	ListInstances(instanceFilter *InstanceFilter) ([]*ServiceInstance, error)
+	ListInstances(filter InstanceFilter) ([]*ServiceInstance, error)
 	ListServiceInstances(serviceName string) ([]*ServiceInstance, error)
 }
 
@@ -135,19 +135,16 @@ func (client *restClient) ListServices() ([]string, error) {
 }
 
 func (client *restClient) ListServiceInstances(serviceName string) ([]*ServiceInstance, error) {
-	return client.ListInstances(&InstanceFilter{
+	return client.ListInstances(InstanceFilter{
 		ServiceName: serviceName,
 	})
 }
 
-func (client *restClient) ListInstances(instanceFilter *InstanceFilter) ([]*ServiceInstance, error) {
+func (client *restClient) ListInstances(filter InstanceFilter) ([]*ServiceInstance, error) {
 	path := amalgam8.InstancesURL()
-	if instanceFilter != nil {
-		queryParams := instanceFilter.asQueryParams()
-		if len(queryParams) > 0 {
-			path = fmt.Sprintf("%s?%s", path, queryParams.Encode())
-		}
-		instanceFilter.asQueryParams()
+	queryParams := filter.asQueryParams()
+	if len(queryParams) > 0 {
+		path = fmt.Sprintf("%s?%s", path, queryParams.Encode())
 	}
 
 	body, err := client.doRequest("GET", path, nil, http.StatusOK)

--- a/client/endpoint.go
+++ b/client/endpoint.go
@@ -1,3 +1,17 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package client
 
 import (

--- a/client/endpoint.go
+++ b/client/endpoint.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// ServiceEndpoint describes a network endpoint of service instance.
+type ServiceEndpoint struct {
+
+	// Type is the endpoint's type. Valid values are "http", "tcp", or "user".
+	Type  string `json:"type"`
+
+	// Value is the endpoint's value according to its type,
+	// e.g. "172.135.10.1:8080" or "http://myapp.ng.bluemix.net/api/v1".
+	Value string `json:"value"`
+}
+
+// NewHTTPEndpoint creates a new HTTP(S) network endpoint with the specified URL.
+// The specified URL is assumed to have an "http" or "https" scheme.
+func NewHTTPEndpoint(httpURL url.URL) ServiceEndpoint {
+	return ServiceEndpoint{
+		Type:  "http",
+		Value: httpURL.String(),
+	}
+}
+
+// NewTCPEndpoint creates a new TCP network endpoint with the specified host and optional port.
+func NewTCPEndpoint(host string, port int) ServiceEndpoint {
+	var value string
+	if port > 0 {
+		value = fmt.Sprintf("%s:%d", host, port)
+	} else {
+		value = host
+	}
+	return ServiceEndpoint{
+		Type:  "tcp",
+		Value: value,
+	}
+}
+
+// NewCustomEndpoint creates a new network endpoint of a custom type.
+// The value may be any arbitrary description of a network endpoint which makes sense in the context of the application.
+func NewCustomEndpoint(endpoint string) ServiceEndpoint {
+	return ServiceEndpoint{
+		Type:  "user",
+		Value: endpoint,
+	}
+}

--- a/client/endpoint.go
+++ b/client/endpoint.go
@@ -23,7 +23,7 @@ import (
 type ServiceEndpoint struct {
 
 	// Type is the endpoint's type. Valid values are "http", "tcp", or "user".
-	Type  string `json:"type"`
+	Type string `json:"type"`
 
 	// Value is the endpoint's value according to its type,
 	// e.g. "172.135.10.1:8080" or "http://myapp.ng.bluemix.net/api/v1".

--- a/client/errors.go
+++ b/client/errors.go
@@ -16,8 +16,10 @@ package client
 
 import "bytes"
 
+// ErrorCode represents an error condition which might occur when using the client.
 type ErrorCode int
 
+// Enumerate valid ErrorCode values.
 const (
 	ErrorCodeUndefined ErrorCode = iota
 
@@ -56,6 +58,7 @@ func (code ErrorCode) String() string {
 	}
 }
 
+// Error represents an actual error occurred which using the client.
 type Error struct {
 	Code      ErrorCode
 	Message   string

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,0 +1,80 @@
+package client
+
+import "bytes"
+
+type ErrorCode int
+
+const (
+	ErrorCodeUndefined ErrorCode = iota
+
+	ErrorCodeUnknownInstance
+
+	ErrorCodeConnectionFailure
+
+	ErrorCodeServiceUnavailable
+	ErrorCodeInternalServerError
+
+	ErrorCodeUnauthorized
+	ErrorCodeInvalidConfiguration
+	ErrorCodeInternalClientError
+)
+
+func (code ErrorCode) String() string {
+	switch code {
+
+	case ErrorCodeUnknownInstance:
+		return "ErrorCodeUnknownInstance"
+	case ErrorCodeConnectionFailure:
+		return "ErrorCodeConnectionFailure"
+	case ErrorCodeServiceUnavailable:
+		return "ErrorCodeServiceUnavailable"
+	case ErrorCodeInternalServerError:
+		return "ErrorCodeInternalServerError"
+	case ErrorCodeUnauthorized:
+		return "ErrorCodeUnauthorized"
+	case ErrorCodeInvalidConfiguration:
+		return "ErrorCodeInvalidConfiguration"
+	case ErrorCodeInternalClientError:
+		return "ErrorCodeInternalClientError"
+
+	default:
+		return "ErrorCodeUndefined"
+	}
+}
+
+type Error struct {
+	Code      ErrorCode
+	Message   string
+	Cause     error
+	RequestID string
+}
+
+func (err Error) Error() string {
+	var buf bytes.Buffer
+	buf.WriteString(err.Code.String())
+	buf.WriteString(": ")
+	buf.WriteString(err.Message)
+
+	if err.Cause != nil {
+		buf.WriteString(" (")
+		buf.WriteString(err.Cause.Error())
+		buf.WriteString(")")
+	}
+
+	if err.RequestID != "" {
+		buf.WriteString(" (")
+		buf.WriteString(err.RequestID)
+		buf.WriteString(")")
+	}
+
+	return buf.String()
+}
+
+func newError(code ErrorCode, message string, cause error, requestID string) Error {
+	return Error{
+		Code:      code,
+		Message:   message,
+		Cause:     cause,
+		RequestID: requestID,
+	}
+}

--- a/client/errors.go
+++ b/client/errors.go
@@ -1,3 +1,17 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package client
 
 import "bytes"

--- a/client/filter.go
+++ b/client/filter.go
@@ -1,3 +1,17 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package client
 
 import (

--- a/client/filter.go
+++ b/client/filter.go
@@ -20,6 +20,9 @@ import (
 )
 
 // InstanceFilter is used to filter service instances returned from lookup calls.
+//
+// The zero-value indicates to use the registry's default filtering, which includes all service instances
+// with status 'UP', and include all fields in the response.
 type InstanceFilter struct {
 
 	// ServiceName is used to filter service instances based on their service name.
@@ -42,7 +45,7 @@ type InstanceFilter struct {
 	// Fields is used to filter the fields returned for each service instance.
 	// When set to a non-empty array, returned service instances will have their corresponding fields set,
 	// while other fields will remain at their zero-value.
-	// When set to an empty or nil array, returned service intances will have all of their fields set.
+	// When set to an empty or nil array, returned service instances will have all of their fields set.
 	Fields []string
 }
 
@@ -59,7 +62,7 @@ const (
 )
 
 // asQueryParams convert the filter into a set of query parameters that can be added to a lookup request.
-func (filter *InstanceFilter) asQueryParams() url.Values {
+func (filter InstanceFilter) asQueryParams() url.Values {
 	queryParams := make(url.Values)
 
 	if filter.ServiceName != "" {

--- a/client/filter.go
+++ b/client/filter.go
@@ -30,6 +30,8 @@ type InstanceFilter struct {
 	// Status is used to filter service instances based on their status.
 	// When set to a non-empty string, registered service instances will be returned
 	// only if their status matches the specified status.
+	// When left empty, only instances with status "UP" will be returned.
+	// When set to "ALL", all instances will be returned, regardless of their status.
 	Status string
 
 	// Tags is used to filter service instances based on their tags.

--- a/client/filter.go
+++ b/client/filter.go
@@ -1,0 +1,66 @@
+package client
+
+import (
+	"net/url"
+	"strings"
+)
+
+// InstanceFilter is used to filter service instances returned from lookup calls.
+type InstanceFilter struct {
+
+	// ServiceName is used to filter service instances based on their service name.
+	// When set to a non-empty string, registered service instances will be returned
+	// only if their service name matches the specified service name.
+	ServiceName string
+
+	// Status is used to filter service instances based on their status.
+	// When set to a non-empty string, registered service instances will be returned
+	// only if their status matches the specified status.
+	Status string
+
+	// Tags is used to filter service instances based on their tags.
+	// When set to a non-empty array, registered service instances will be returned
+	// only if they are tagged with each of the specified tags.
+	Tags []string
+
+	// Fields is used to filter the fields returned for each service instance.
+	// When set to a non-empty array, returned service instances will have their corresponding fields set,
+	// while other fields will remain at their zero-value.
+	// When set to an empty or nil array, returned service intances will have all of their fields set.
+	Fields []string
+}
+
+// Enumerates available values for InstanceField.
+const (
+	FieldID            = "id"
+	FieldServiceName   = "service_name"
+	FieldEndpoint      = "endpoint"
+	FieldStatus        = "status"
+	FieldTags          = "tags"
+	FieldMetadata      = "metadata"
+	FieldTTL           = "ttl"
+	FieldLastHeartbeat = "last_heartbeat"
+)
+
+// asQueryParams convert the filter into a set of query parameters that can be added to a lookup request.
+func (filter *InstanceFilter) asQueryParams() url.Values {
+	queryParams := make(url.Values)
+
+	if filter.ServiceName != "" {
+		queryParams.Add("service_name", filter.ServiceName)
+	}
+
+	if filter.Status != "" {
+		queryParams.Add("status", filter.Status)
+	}
+
+	if len(filter.Tags) > 0 {
+		queryParams.Add("tags", strings.Join(filter.Tags, ","))
+	}
+
+	if len(filter.Fields) > 0 {
+		queryParams.Add("fields", strings.Join(filter.Fields, ","))
+	}
+
+	return queryParams
+}

--- a/client/instance.go
+++ b/client/instance.go
@@ -1,3 +1,17 @@
+// Copyright 2016 IBM Corporation
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+
 package client
 
 import (

--- a/client/instance.go
+++ b/client/instance.go
@@ -1,0 +1,46 @@
+package client
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// ServiceInstance holds information about a service instance registered with Amalgam8 Service Registry.
+//
+// It is used both as an input to registration calls, as well as the output of discovery calls.
+// Depending on the context, some of the fields may be mandatory, optional, or ignored.
+type ServiceInstance struct {
+
+	// ID is the unique ID assigned to this service instance by Amalgam8 Service Registry.
+	// This field is ignored for registration, and is mandatory for discovery.
+	ID            string          `json:"id,omitempty"`
+
+	// ServiceName is the name of the service being provided by this service instance.
+	// This field is mandatory both for registration and discovery.
+	ServiceName   string          `json:"service_name"`
+
+	// Endpoint is the network endpoint of this service instance.
+	// This field is mandatory both for registration and discovery.
+	Endpoint      ServiceEndpoint `json:"endpoint"`
+
+	// Status is an arbitrary string representing the status of the service instance, e.g. "UP" or "DOWN".
+	// This field is optional both for registration and discovery.
+	Status        string          `json:"status,omitempty"`
+
+	// Tags is a set of arbitrary tags attached to this service instance.
+	// This field is optional both for registration and discovery.
+	Tags          []string        `json:"tags,omitempty"`
+
+	// Metadata is a marshaled JSON value associated with this service instance, in encoded-form.
+	// Any arbitrary JSON value is valid, including numbers, strings, arrays and objects.
+	// This field is optional both for registration and discovery.
+	Metadata      json.RawMessage `json:"metadata,omitempty"`
+
+	// TTL is the time-to-live associated with this service instance, specified in seconds.
+	// This field is optional for registration, and is mandatory for discovery.
+	TTL           int             `json:"ttl,omitempty"`
+
+	// LastHeartbeat is the timestamp in which heartbeat has been last received for this service instance.
+	// This field is ignored for registration, and is mandatory for discovery.
+	LastHeartbeat time.Time       `json:"last_heartbeat,omitempty"`
+}

--- a/client/instance.go
+++ b/client/instance.go
@@ -37,7 +37,8 @@ type ServiceInstance struct {
 	// This field is mandatory both for registration and discovery.
 	Endpoint      ServiceEndpoint `json:"endpoint"`
 
-	// Status is an arbitrary string representing the status of the service instance, e.g. "UP" or "DOWN".
+	// Status is a string representing the status of the service instance.
+	// Valid values are "STARTING", "UP", or "OUT_OF_SERVICE".
 	// This field is optional both for registration and discovery.
 	Status        string          `json:"status,omitempty"`
 

--- a/client/instance.go
+++ b/client/instance.go
@@ -27,35 +27,35 @@ type ServiceInstance struct {
 
 	// ID is the unique ID assigned to this service instance by Amalgam8 Service Registry.
 	// This field is ignored for registration, and is mandatory for discovery.
-	ID            string          `json:"id,omitempty"`
+	ID string `json:"id,omitempty"`
 
 	// ServiceName is the name of the service being provided by this service instance.
 	// This field is mandatory both for registration and discovery.
-	ServiceName   string          `json:"service_name"`
+	ServiceName string `json:"service_name"`
 
 	// Endpoint is the network endpoint of this service instance.
 	// This field is mandatory both for registration and discovery.
-	Endpoint      ServiceEndpoint `json:"endpoint"`
+	Endpoint ServiceEndpoint `json:"endpoint"`
 
 	// Status is a string representing the status of the service instance.
 	// Valid values are "STARTING", "UP", or "OUT_OF_SERVICE".
 	// This field is optional both for registration and discovery.
-	Status        string          `json:"status,omitempty"`
+	Status string `json:"status,omitempty"`
 
 	// Tags is a set of arbitrary tags attached to this service instance.
 	// This field is optional both for registration and discovery.
-	Tags          []string        `json:"tags,omitempty"`
+	Tags []string `json:"tags,omitempty"`
 
 	// Metadata is a marshaled JSON value associated with this service instance, in encoded-form.
 	// Any arbitrary JSON value is valid, including numbers, strings, arrays and objects.
 	// This field is optional both for registration and discovery.
-	Metadata      json.RawMessage `json:"metadata,omitempty"`
+	Metadata json.RawMessage `json:"metadata,omitempty"`
 
 	// TTL is the time-to-live associated with this service instance, specified in seconds.
 	// This field is optional for registration, and is mandatory for discovery.
-	TTL           int             `json:"ttl,omitempty"`
+	TTL int `json:"ttl,omitempty"`
 
 	// LastHeartbeat is the timestamp in which heartbeat has been last received for this service instance.
 	// This field is ignored for registration, and is mandatory for discovery.
-	LastHeartbeat time.Time       `json:"last_heartbeat,omitempty"`
+	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
 }


### PR DESCRIPTION
A client package aimed to be used by other components (controller, sidecar, tests) that interact with the registry over HTTP.

- This package currently depends on the 'api/protocol/amalgam8' package which defines the API endpoint paths.
- This package redeclares several types defined in the 'api/protocol/amalgam8' package (ServiceInstance, etc), so that a consumer of the client can interact with a single package only.