### PR TITLE
Travis support for releasing binaries to GitHub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 
 # Build
 bin/
+release/
 
 # Logs
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,43 @@
 language: go
 
+# Enable Travis container-based infrastructure
+sudo: false
+
+# Go versions to build with
 go:
     - 1.6
     - 1.5
 
 env:
     global:
+        # Required for Go 1.5 build
         - GO15VENDOREXPERIMENT=1
-        
-script:
-    - make verify
+    matrix:
+        # Platforms to build for
+        - PLATFORM=linux/amd64
 
-sudo: false
+script:
+    # Need to set explicitly, as these are unset by 'gimme'
+    - export GOOS=${PLATFORM%/*}
+    - export GOARCH=${PLATFORM#*/}
+    
+    # Analyze, test and build the code, and then package the binary
+    - make verify release
+
+deploy:
+    
+    # Upload files to GitHub as release attachments
+    provider: releases
+    api_key: $GITHUB_TOKEN
+      
+    # Keep artifacts produced during the build
+    skip_cleanup: true
+    
+    # Upload anything under the release directory
+    file_glob: true
+    file: release/*
+
+    # Trigger only when building a tagged commit, on Go 1.6
+    on:
+        tags: true
+        go: 1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,10 @@
 
 FROM scratch
 
-WORKDIR /opt/registry
-COPY bin/registry       /opt/registry/
-COPY messages        /opt/registry/locales
+WORKDIR /opt/a8registry
+COPY bin/a8registry       /opt/a8registry/
+COPY messages        /opt/a8registry/locales
 
 EXPOSE 8080
 
-ENTRYPOINT [ "/opt/registry/registry" ]
+ENTRYPOINT [ "/opt/a8registry/a8registry" ]

--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,26 @@
 SHELL 		:= /bin/bash
 APP_NAME	:= registry
 APP_VER		:= 0.1
-IMAGE_NAME  := $(APP_NAME):$(APP_VER)
 BINDIR		:= bin
+RELEASEDIR  := release
 
 GO			:= GO15VENDOREXPERIMENT=1 go
+
+ifndef GOOS
+    GOOS := $(shell $(GO) env GOHOSTOS)
+endif
+
+ifndef GOARCH
+	GOARCH := $(shell $(GO) env GOHOSTARCH)
+endif
 
 GOFILES		= $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 GODIRS		= $(shell $(GO) list -f '{{.Dir}}' ./... | grep -vxFf <($(GO) list -f '{{.Dir}}' ./vendor/...))
 GOPKGS		= $(shell $(GO) list ./... | grep -vxFf <($(GO) list ./vendor/...))
 
+IMAGE_NAME   := $(APP_NAME):$(APP_VER)
+RELEASE_NAME := $(APP_NAME)-$(APP_VER)-$(GOOS)-$(GOARCH)
+	
 # build flags to create a statically linked binary (required for scratch-based image)
 BUILDFLAGS	:= -a -installsuffix nocgo -tags netgo
 
@@ -58,12 +69,17 @@ precommit: format verify
 #---------
 #-- build
 #---------
-.PHONY: build compile clean
+.PHONY: build compile clean release
 
 build:
 	@echo "--> building executable"
 	@$(GO) build $(BUILDFLAGS) -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(APP_NAME)
 
+release: build
+	@echo "--> package release"
+	@mkdir -p $(RELEASEDIR) 
+	@tar -czf $(RELEASEDIR)/$(RELEASE_NAME).tar.gz --transform 's:^.*/::' $(BINDIR)/$(APP_NAME) README.md LICENSE
+	
 compile:
 	@echo "--> compiling packages"
 	@$(GO) build $(GOPKGS)
@@ -72,6 +88,7 @@ clean:
 	@echo "--> cleaning compiled objects and binaries"
 	@$(GO) clean -tags netgo -i $(GOPKGS)
 	@rm -rf $(BINDIR)/*
+	@rm -rf $(RELEASEDIR)/*
 
 #--------
 #-- test
@@ -130,6 +147,7 @@ depend.install:	tools.glide
 docker:
 	@echo "--> building docker image"
 	@docker build -t $(IMAGE_NAME) .
+
 
 #---------------
 #-- tools

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #------------------------------------------------------------------------------
 
 SHELL 		:= /bin/bash
-APP_NAME	:= registry
+APP_NAME	:= a8registry
 APP_VER		:= 0.1
 BINDIR		:= bin
 RELEASEDIR  := release

--- a/Makefile
+++ b/Makefile
@@ -69,17 +69,12 @@ precommit: format verify
 #---------
 #-- build
 #---------
-.PHONY: build compile clean release
+.PHONY: build compile clean
 
 build:
 	@echo "--> building executable"
 	@$(GO) build $(BUILDFLAGS) -ldflags '$(LDFLAGS)' -o $(BINDIR)/$(APP_NAME)
 
-release: build
-	@echo "--> package release"
-	@mkdir -p $(RELEASEDIR) 
-	@tar -czf $(RELEASEDIR)/$(RELEASE_NAME).tar.gz --transform 's:^.*/::' $(BINDIR)/$(APP_NAME) README.md LICENSE
-	
 compile:
 	@echo "--> compiling packages"
 	@$(GO) build $(GOPKGS)
@@ -140,15 +135,19 @@ depend.install:	tools.glide
 	@glide install --strip-vcs --update-vendored
 	
 #----------
-#-- docker
+#-- artifacts
 #----------
-.PHONY: docker
+.PHONY: docker release
 
 docker:
 	@echo "--> building docker image"
 	@docker build -t $(IMAGE_NAME) .
-
-
+	
+release:
+	@echo "--> packaging release"
+	@mkdir -p $(RELEASEDIR) 
+	@tar -czf $(RELEASEDIR)/$(RELEASE_NAME).tar.gz --transform 's:^.*/::' $(BINDIR)/$(APP_NAME) README.md LICENSE
+		
 #---------------
 #-- tools
 #---------------


### PR DESCRIPTION
This PR enhances the Travis build to uploaded packaged binaries (e.g., `a8registry-v0.1.0-linux-amd64.tar.gz`) as release attachments in GitHub, whenever a tagged commit is built.