### PR TITLE
Travis: deploy tagged images to Docker Hub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 
-# Enable Travis container-based infrastructure
-sudo: false
+# Require Travis to use a docker-enabled virtualization environment for the build
+sudo: required
+services:
+  - docker
 
 # Go versions to build with
 go:
@@ -27,17 +29,32 @@ script:
 deploy:
     
     # Upload files to GitHub as release attachments
-    provider: releases
-    api_key: $GITHUB_TOKEN
+    -   provider: releases
+        api_key: $GITHUB_TOKEN
       
-    # Keep artifacts produced during the build
-    skip_cleanup: true
+        # Keep artifacts produced during the build
+        skip_cleanup: true
     
-    # Upload anything under the release directory
-    file_glob: true
-    file: release/*
+        # Upload anything under the release directory
+        file_glob: true
+        file: release/*
 
-    # Trigger only when building a tagged commit, on Go 1.6
-    on:
-        tags: true
-        go: 1.6
+        # Trigger only when building a tagged commit, on the origin repo, and with Go 1.6
+        on:
+            tags: true
+            repo: amalgam8/registry
+            go: 1.6
+
+    # Push images to Docker Hub
+    -   provider: script
+        script: ./scripts/push_dockerhub.sh
+    
+        # Keep artifacts produced during the build
+        skip_cleanup: true
+            
+        # Trigger only when building a version-tagged commit, on Go 1.6
+        on:
+            tags: true
+            repo: amalgam8/registry
+            go: 1.6
+            condition: $TRAVIS_TAG =~ v[0-9]+\.[0-9]+\.[0-9]+

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,3 +58,15 @@ deploy:
             repo: amalgam8/registry
             go: 1.6
             condition: $TRAVIS_TAG =~ v[0-9]+\.[0-9]+\.[0-9]+
+
+# Configure notifications
+notifications:
+    email:
+        on_success: never
+        on_failure: always
+    slack:
+        rooms:
+            - amalgam8:$TRAVIS_TOKEN
+        on_success: always
+        on_failure: always
+        on_pull_requests: true

--- a/scripts/push_dockerhub.sh
+++ b/scripts/push_dockerhub.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+###################################################################
+### Build, tag and push semantically-versioned images to Docker Hub
+###
+### This script is intended to be run in a Travis-CI build context,
+### where the current commit is tagged with a semantic version tag (e.g. "v3.12.7")
+### The following environment variables are assumed to be set:
+###
+### - DOCKERHUB_EMAIL - Dockerhub login email
+### - DOCKERHUB_USERNAME - Docker Hub login username
+### - DOCKERHUB_PASSWORD - Docker Hub login password
+###############################################################
+
+DOCKER_IMAGE="amalgam8/a8registry"
+
+tag=$(git describe --exact-match)
+if [ $? -ne 0 ]; then
+    echo "Cannot push to Docker Hub because the current commit is not tagged"
+    exit 1
+elif [[ ! $tag =~ v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+    echo "Cannot push to Docker Hub because the current commit is not tagged in a semantic version"
+    exit 1
+fi
+
+patch=$(echo $tag | sed -r 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\3/')
+minor=$(echo $tag | sed -r 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\2/')
+major=$(echo $tag | sed -r 's/v([0-9]+)\.([0-9]+)\.([0-9]+)/\1/')
+
+echo "Found version tag '$tag' (MAJOR: $major, MINOR: $minor, PATCH: $patch)"
+
+patch_tag="$major.$minor.$patch"
+minor_tag="$major.$minor"
+major_tag="$major"
+
+echo "Building docker image..."
+docker build -t "$DOCKER_IMAGE:latest" .
+
+echo "Listing current image tags in Docker Hub..."
+dockerhub_tags=$(curl --silent "https://registry.hub.docker.com/v1/repositories/$DOCKER_IMAGE/tags" | jq -r ".[].name")
+
+# Always push the patch version tag (e.g., '3.12.7')
+push_patch=true
+
+# Determine if the minor tag (e.g., '3.12') should be pushed
+max_patch=$(echo "dockerhub_tags" | sed -rn "s/$minor_tag\.([0-9]+)/\1/p" | sort -r | head -n1)
+if [[ -z "$max_patch" || $patch -ge $max_patch ]]; then
+    push_minor=true
+fi
+
+# Determine if the major tag (e.g., '3') should be pushed
+max_minor=$(echo "dockerhub_tags" | sed -rn "s/$major_tag\.([0-9]+)\.[0-9]+/\1/p" | sort -r | head -n1)
+if [[ $major -gt 0 && $push_minor = true && ( -z "$max_minor" || $minor -ge $max_minor ) ]]; then
+    push_major=true
+fi
+
+# Determine if the 'latest' tag should be pushed
+max_major=$(echo "dockerhub_tags" | sed -rn "s/([0-9]+)\.[0-9]+\.[0-9]+/\1/p" | sort -r | head -n1)
+if [[ ( $push_major = true || $major -eq 0 ) && $push_minor = true && ( -z "$max_major" || $major -ge $max_major ) ]]; then
+    push_latest=true
+fi
+
+echo "Signing into Docker Hub..."
+docker login --email $DOCKERHUB_EMAIL --username $DOCKERHUB_USERNAME --password $DOCKERHUB_PASSWORD
+
+if [ "$push_patch" = true ]; then
+    echo "Pushing '$DOCKER_IMAGE:$patch_tag' to Docker Hub..."
+    docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$patch_tag"
+    docker push "$DOCKER_IMAGE:$patch_tag"
+fi
+if [ "$push_minor" = true ]; then
+    echo "Pushing '$DOCKER_IMAGE:$minor_tag' to Docker Hub..."
+    docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$minor_tag"
+    docker push "$DOCKER_IMAGE:$minor_tag"
+fi
+if [ "$push_major" = true ]; then
+    echo "Pushing '$DOCKER_IMAGE:$major_tag' to Docker Hub..."
+    docker tag "$DOCKER_IMAGE:latest" "$DOCKER_IMAGE:$major_tag"
+    docker push "$DOCKER_IMAGE:$major_tag"
+fi
+if [ "$push_latest" = true ]; then
+    echo "Pushing '$DOCKER_IMAGE:latest' to Docker Hub..."
+    docker push "$DOCKER_IMAGE:latest"
+fi
+
+echo "Signing out of Docker Hub"
+docker logout

--- a/scripts/push_dockerhub.sh
+++ b/scripts/push_dockerhub.sh
@@ -12,7 +12,7 @@
 ### - DOCKERHUB_PASSWORD - Docker Hub login password
 ###############################################################
 
-DOCKER_IMAGE="amalgam8/a8registry"
+DOCKER_IMAGE="amalgam8/a8-registry"
 
 tag=$(git describe --exact-match)
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This PR adds support for building, tagging and pushing versioned images into Docker Hub, as part of Travis-CI build.

- Triggers only when building a commit tagged with a semantic version (e.g., `v3.42.1`).
- Pushes several tags (aliases) for the image (e.g., `3.42.1`, `3.42`, `3`, `latest`).
   - But only if doesn't overwrite newer tags (aliases).
   - For example, if tags  `3`, `3.42`,  `3.43` are already in Docker Hub, then  building `v3.42.1` will push `3.42.1`, `3.42`, but will NOT push `3`, `latest` (because `latest`=`3`=`3.43`).
- Depends on the following environments variables to be defined in Travis-CI repo settings:
   - DOCKERHUB_EMAIL
   - DOCKERHUB_USERNAME
   - DOCKERHUB_PASSWORD

