### PR TITLE
Change "Global Auth" to "Default Auth"

### DIFF
--- a/auth/authenticator.go
+++ b/auth/authenticator.go
@@ -19,10 +19,7 @@ const module = "AUTH"
 
 // Authenticator is an interface for token authentication
 type Authenticator interface {
-	Authenticate(token string) (*Namespace, error)
-}
 
-// DefaultAuthenticator returns the default authenticator provided by this package
-func DefaultAuthenticator() Authenticator {
-	return NewGlobalAuthenticator()
+	// Authenticate resolves an arbitrary string token into a namespace.
+	Authenticate(token string) (*Namespace, error)
 }

--- a/auth/default.go
+++ b/auth/default.go
@@ -14,21 +14,20 @@
 
 package auth
 
-type globalAuthenticator struct{}
+type defaultAuthenticator struct{}
 
-var globalAuth = &globalAuthenticator{}
+var defaultAuth = &defaultAuthenticator{}
+var defaultNamespace = Namespace("default")
 
-// NewGlobalAuthenticator creates a global authenticator instance
-func NewGlobalAuthenticator() Authenticator {
-	return globalAuth
+// DefaultAuthenticator returns the default authenticator provided by this package,
+// which resolves "" (empty string) as well as "default" token to the default namespace.
+func DefaultAuthenticator() Authenticator {
+	return defaultAuth
 }
 
-var globalNamespace = Namespace("global")
-
-func (aut *globalAuthenticator) Authenticate(token string) (*Namespace, error) {
-	if token == "" {
-		return &globalNamespace, nil
+func (aut *defaultAuthenticator) Authenticate(token string) (*Namespace, error) {
+	if token == "" || token == defaultNamespace.String() {
+		return &defaultNamespace, nil
 	}
-
 	return nil, ErrUnrecognizedToken
 }

--- a/auth/default_test.go
+++ b/auth/default_test.go
@@ -20,15 +20,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestValidGlobalToken(t *testing.T) {
-	g := globalAuth
-	namespace, err := g.Authenticate("")
+func TestDefaultAuthenticatorEmptyToken(t *testing.T) {
+	auth := DefaultAuthenticator()
+	namespace, err := auth.Authenticate("")
 	assert.NoError(t, err)
-	assert.EqualValues(t, globalNamespace, *namespace)
+	assert.EqualValues(t, defaultNamespace, *namespace)
 }
 
-func TestInvalidGlobalToken(t *testing.T) {
-	g := globalAuth
-	_, err := g.Authenticate("invalid-token")
+func TestDefaultAuthenticatorDefaultToken(t *testing.T) {
+	auth := DefaultAuthenticator()
+	namespace, err := auth.Authenticate(defaultNamespace.String())
+	assert.NoError(t, err)
+	assert.EqualValues(t, defaultNamespace, *namespace)
+}
+
+func TestDefaultAuthenticatorInvalidToken(t *testing.T) {
+	auth := DefaultAuthenticator()
+	namespace, err := auth.Authenticate("invalid-token")
 	assert.Error(t, err)
+	assert.Nil(t, namespace)
 }


### PR DESCRIPTION
- Rename `auth.globalAuthenticator` to `auth.defaultAuthenticator` (and corresponding source files)
- Rename default (global) namespace from _"global"_ to _"default"_ (aligns with k8s default namespace)
- In default auth mode, accepts both _""_ (empty) and  _"default"_ tokens (to avoid Eureka's `api/eureka//v2/` URLs)